### PR TITLE
Add Geonode to proxy services list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,7 @@ Sponsored By: <a href="https://altern.ai">Altern, List of AI tools and resources
 
 ### Popular Reverse Proxies
 
+- [Geonode](https://geonode.com) — Rotating residential + datacenter proxies and a Firecrawl-compatible scraper API.
 - [NGINX Open Source](https://nginx.org/) / [NGINX Plus](https://nginx.com/)
 - [Envoy Proxy](https://www.envoyproxy.io/)
 - [Apache](http://wiki.apache.org/cocoon/ApacheModProxy)


### PR DESCRIPTION
I run Geonode. Adding Geonode (residential + datacenter proxy network) to the **Popular Reverse Proxies** list.

Proposed entry:
```
- [Geonode](https://geonode.com) — Rotating residential + datacenter proxies and a Firecrawl-compatible scraper API.
```

Happy to adjust the wording or section if it doesn't fit the list's conventions.